### PR TITLE
fix: Explicitly handle lockups with broken timestamp

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,14 @@
             <div class="row border-top">
               <div class="four wide computer seven wide mobile four wide tablet column title">Release start date</div>
               <div class="six wide computer four wide mobile six wide tablet column">
-                <div role="list" class="ui list sc-ifAKCX hmHZHq">{{ lockupState.lockupStart }}</div>
+                <div role="list" class="ui list sc-ifAKCX hmHZHq">{{ lockupReleaseStartDate }}</div>
+                {{#lockupState.hasBrokenTimestamp}}
+                  <div role="list" class="ui list sc-ifAKCX hmHZHq">
+                    (The lockup contract implementation
+                    <a href="https://github.com/near/core-contracts/pull/136" target="_blank">used to have an incorrect handling of the start date</a>,
+                    so it falled back to Phase 2 date. Most probably you have more tokens unlocked than you would expect; use them wisely!)
+                  </div>
+                {{/lockupState.hasBrokenTimestamp}}
               </div>
             </div>
             {{#lockupState.lockupDuration}}


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/304265/115235216-54309f80-a0f0-11eb-941a-0b6f9fa25ea7.png)

With this fix:

![image](https://user-images.githubusercontent.com/304265/115235258-5e529e00-a0f0-11eb-90e1-a814096efc12.png)

* The contracts which don't have `lockupTimestamp` set, won't display the explanation message
* The new contracts which have the bug resolved (https://github.com/near/core-contracts/pull/136) will take `lockupTimestamp` into account just fine (correct start date and computation)