### PR TITLE
wip: fix total lockup balance

### DIFF
--- a/script.js
+++ b/script.js
@@ -366,12 +366,12 @@ async function lookup() {
         2
       ),
       liquidAmount: nearAPI.utils.format.formatNearAmount(
-        new BN(lockupAccountBalance).sub(new BN(lockedAmount)).toString(),
+        lockupState.lockupAmount.sub(new BN(lockedAmount)).toString(),
         2
       ),
       totalAmount: nearAPI.utils.format.formatNearAmount(
         new BN(ownerAccountBalance)
-          .add(new BN(lockupAccountBalance))
+          .add(lockupState.lockupAmount)
           .toString(),
         2
       ),


### PR DESCRIPTION
Story
we have an account https://explorer.near.org/accounts/opgran01.near
we checked the info for this account at the moment 31 dec 2020 (block_height 26490580)
the script told us this account had 40 tokens as the owner and 35 tokens on the lockup
but in reality, the lockup had huge amount of money and we have the TX about it
https://explorer.near.org/transactions/3db8TpxEu1kSB4v4mPRBCqHsBBna8Zfq2Jkvf67A4CVs

@frol could you please check this fix carefully? I have no idea how it's possible that we still have an error here. I did my best in fixing that but I still doubt whether it's fine